### PR TITLE
Hardcoding 'localhost' into network.py and server.py

### DIFF
--- a/game/trivial_compute/net/network.py
+++ b/game/trivial_compute/net/network.py
@@ -11,8 +11,7 @@ class Network:
         self.p = self.connect()
 
     def get_local_ip(self):
-        hostname = socket.gethostname()
-        local_ip = socket.gethostbyname(hostname)
+        local_ip = socket.gethostbyname('localhost')
         return local_ip
 
     def getP(self):

--- a/game/trivial_compute/net/server.py
+++ b/game/trivial_compute/net/server.py
@@ -22,8 +22,7 @@ class Server:
         self.connected_players = []
 
     def get_local_ip(self):
-        hostname = socket.gethostname()
-        local_ip = socket.gethostbyname(hostname)
+        local_ip = socket.gethostbyname('localhost')
         return local_ip
 
     def configure_player_count(self):


### PR DESCRIPTION
make run_tc currently gives an error due to not resolving the IP from a hostname.

This program is always expected to run locally for now, so hardcoding 'localhost' in the get_local_ip function for the server and network files.